### PR TITLE
Use new URL to download the Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This attributes can be used to further customize the application:
 - `wrapper_cpu`: the cpu for the java wrapper, defaults to x86
 - `wrapper_bit`: the architecture for the java wrapper, defaults to 64
 - `wrapper_extension`: the extension for the java wrapper, defaults to tar.gz
-- `wrapper_url`: the url to download the wrapper, defaults to "http://wrapper.tanukisoftware.com/download/#{wrapper_version}/wrapper-#{wrapper_os}-#{wrapper_cpu}-#{wrapper_bit}-#{wrapper_version}.#{wrapper_extension}"
+- `wrapper_url`: the url to download the wrapper, defaults to "http://download.tanukisoftware.com/wrapper/#{wrapper_version}/wrapper-#{wrapper_os}-#{wrapper_cpu}-#{wrapper_bit}-#{wrapper_version}.#{wrapper_extension}"
 - `file_logging_enabled`: cause file logging to be disabled if set to false. Boolean. True by default.
 
 Usage

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -59,7 +59,7 @@ def extract_native_lib
              end
 
   ark 'java_wrapper_native_lib' do
-    url "http://wrapper.tanukisoftware.com/download/#{new_resource.wrapper_version}/wrapper-#{new_resource.wrapper_os}-"\
+    url "http://download.tanukisoftware.com/wrapper/#{new_resource.wrapper_version}/wrapper-#{new_resource.wrapper_os}-"\
       "#{new_resource.wrapper_cpu}-#{new_resource.wrapper_bit}-#{new_resource.wrapper_version}.#{new_resource.wrapper_extension}"
     action :cherry_pick
     path new_resource.native_library_dest_dir
@@ -122,7 +122,7 @@ def create_app_with_wrapper
   end
 
   ark 'java_wrapper' do
-    url "http://wrapper.tanukisoftware.com/download/#{new_resource.wrapper_version}/wrapper-#{new_resource.wrapper_os}-"\
+    url "http://download.tanukisoftware.com/wrapper/#{new_resource.wrapper_version}/wrapper-#{new_resource.wrapper_os}-"\
       "#{new_resource.wrapper_cpu}-#{new_resource.wrapper_bit}-#{new_resource.wrapper_version}.#{new_resource.wrapper_extension}"
   end
 

--- a/spec/unit/recipes/native_lib_spec.rb
+++ b/spec/unit/recipes/native_lib_spec.rb
@@ -11,7 +11,7 @@ describe 'java_wrapper_test::native_lib' do
 
   it 'extracts native library' do
     expect(chef_run).to cherry_pick_ark('java_wrapper_native_lib').with(
-      url: 'http://wrapper.tanukisoftware.com/download/3.5.21/wrapper-linux-x86-64-3.5.21.tar.gz',
+      url: 'http://download.tanukisoftware.com/wrapper/3.5.21/wrapper-linux-x86-64-3.5.21.tar.gz',
       action: [:cherry_pick],
       path: '/usr/local/java_wrapper/lib',
       creates: 'wrapper-linux-x86-64-3.5.21/lib/libwrapper.so'

--- a/spec/unit/recipes/test_default_spec.rb
+++ b/spec/unit/recipes/test_default_spec.rb
@@ -11,7 +11,7 @@ describe 'java_wrapper_test::default' do
 
   it 'uses ark to download java wrapper archive' do
     expect(chef_run).to install_ark('java_wrapper').with(
-      url: 'http://wrapper.tanukisoftware.com/download/3.5.21/wrapper-linux-x86-64-3.5.21.tar.gz',
+      url: 'http://download.tanukisoftware.com/wrapper/3.5.21/wrapper-linux-x86-64-3.5.21.tar.gz',
       action: [:install]
     )
   end


### PR DESCRIPTION
The old URL "http://wrapper.tanukisoftware.com/download/..." is a redirection to the new URL "http://download.tanukisoftware.com/wrapper/..."